### PR TITLE
feat(core): MVP prayers, notifications, news demo, Quran sample, i18n, live embed, social stubs

### DIFF
--- a/public/_locales/ar/messages.json
+++ b/public/_locales/ar/messages.json
@@ -22,6 +22,7 @@
   "tab_daily": { "message": "Daily" },
   "tab_live": { "message": "Live" },
   "tab_social": { "message": "Social" },
+  "options_button": { "message": "خيارات" },
   "opt_method": { "message": "Method" },
   "opt_madhab": { "message": "Madhab" },
   "opt_latrule": { "message": "Latitude rule" },

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -22,6 +22,7 @@
   "tab_daily": { "message": "Daily" },
   "tab_live": { "message": "Live" },
   "tab_social": { "message": "Social" },
+  "options_button": { "message": "Options" },
   "opt_method": { "message": "Method" },
   "opt_madhab": { "message": "Madhab" },
   "opt_latrule": { "message": "Latitude rule" },

--- a/public/_locales/hu/messages.json
+++ b/public/_locales/hu/messages.json
@@ -22,6 +22,7 @@
   "tab_daily": { "message": "Napi" },
   "tab_live": { "message": "Élő" },
   "tab_social": { "message": "Közösség" },
+  "options_button": { "message": "Beállítások" },
   "opt_method": { "message": "Módszer" },
   "opt_madhab": { "message": "Madhab" },
   "opt_latrule": { "message": "Szélességi szabály" },

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -22,6 +22,7 @@
   "tab_daily": { "message": "Daily" },
   "tab_live": { "message": "Live" },
   "tab_social": { "message": "Social" },
+  "options_button": { "message": "Настройки" },
   "opt_method": { "message": "Method" },
   "opt_madhab": { "message": "Madhab" },
   "opt_latrule": { "message": "Latitude rule" },

--- a/public/_locales/tr/messages.json
+++ b/public/_locales/tr/messages.json
@@ -22,6 +22,7 @@
   "tab_daily": { "message": "Daily" },
   "tab_live": { "message": "Live" },
   "tab_social": { "message": "Social" },
+  "options_button": { "message": "Seçenekler" },
   "opt_method": { "message": "Method" },
   "opt_madhab": { "message": "Madhab" },
   "opt_latrule": { "message": "Latitude rule" },

--- a/public/_locales/ur/messages.json
+++ b/public/_locales/ur/messages.json
@@ -22,6 +22,7 @@
   "tab_daily": { "message": "Daily" },
   "tab_live": { "message": "Live" },
   "tab_social": { "message": "Social" },
+  "options_button": { "message": "اختیارات" },
   "opt_method": { "message": "Method" },
   "opt_madhab": { "message": "Madhab" },
   "opt_latrule": { "message": "Latitude rule" },

--- a/src/lib/options.ts
+++ b/src/lib/options.ts
@@ -1,0 +1,6 @@
+/**
+ * Opens the extension's Options page in a new browser tab.
+ */
+export function openOptionsPage(): void {
+  chrome.runtime.openOptionsPage();
+}

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -13,6 +13,7 @@
       <button data-tab="live"></button>
       <button data-tab="social"></button>
     </div>
+    <button id="options-btn"></button>
     <div id="content"></div>
     <script type="module" src="./main.ts"></script>
   </body>

--- a/src/popup/main.ts
+++ b/src/popup/main.ts
@@ -7,6 +7,7 @@ import { render as renderSocial } from '../ui/popup/sections/Social';
 import { setLanguage, getMessage } from '../lib/i18n';
 import { getSettings } from '../lib/storage';
 import { applyStyles } from '../ui/style';
+import { openOptionsPage } from '../lib/options';
 
 
 const sections: Record<string, (el: HTMLElement) => void | Promise<void>> = {
@@ -23,6 +24,10 @@ async function init() {
   await setLanguage(settings.language || 'en');
   const content = document.getElementById('content')!;
   applyStyles();
+
+  const optionsBtn = document.getElementById('options-btn')!;
+  optionsBtn.textContent = getMessage('options_button');
+  optionsBtn.addEventListener('click', openOptionsPage);
 
   document.querySelectorAll('#tab-bar button').forEach(btn => {
     const key = btn.getAttribute('data-tab')!;


### PR DESCRIPTION
## Summary
- add Options button to popup and localize label
- add helper for opening options page
- wire popup to open Options

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689dc5be41b88323836fbfe978281332